### PR TITLE
Adding ability to edit individual salelines

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -65,6 +65,10 @@ body {
   text-align: center;
 }
 
+.handbtn{
+  cursor:pointer;
+}
+
 /*
 slide-enter-setup
 slide-leave-setup

--- a/php/AddEditSale.php
+++ b/php/AddEditSale.php
@@ -47,12 +47,15 @@
         $saleLineToDelete->deleteSaleLine($conn);
     }
 
-    //Insert them into the database
+    //Insert new ones and update existing ones
     foreach ($saleLines as $saleLine){
         if ($saleLine->getId() > 0){
-            continue; //already in the database!
+            //Already in the database!
+            $saleLine->updateSaleLine($conn);
         }
-        $saleLine->addNewSaleLine($conn);
+        else{
+            $saleLine->addNewSaleLine($conn);
+        }
     }
     mysqli_close($conn);
 ?>

--- a/php/GetProductsInGroupFromProductId.php
+++ b/php/GetProductsInGroupFromProductId.php
@@ -1,0 +1,36 @@
+<?php
+
+    include_once('product.php');
+
+    $productId = $_GET['ProductId'];  //Get the Product Group Selected
+
+    require("settings.php");
+    $conn = mysqli_connect($host, $user, $pwd, $sql_db);
+
+    if (mysqli_connect_errno())
+    {
+        return false;
+    }
+
+    $query = "SELECT ProductGroupId FROM Product WHERE Id = $productId";
+    $result = mysqli_query($conn, $query);
+    $productGroupId = mysqli_fetch_row($result)[0];
+
+    $query = "SELECT * FROM Product WHERE ProductGroupId = $productGroupId";
+    $result = mysqli_query($conn, $query);
+
+    $products = array();
+    while($r = mysqli_fetch_array($result)) {
+        $products[] = Product::getProductFromDBRow($r);
+    }
+
+    $json = "{
+        \"productGroupId\" : \"$productGroupId\",
+        \"products\" : " . json_encode($products) .
+    "}";
+
+    echo $json;
+
+    mysqli_free_result($result);
+    mysqli_close($conn);
+?>

--- a/php/saleline.php
+++ b/php/saleline.php
@@ -90,30 +90,19 @@
         $result = $this->WriteDelDbase($sqltable, $query, $insertId);
 
         $this->setId($insertId);
+        return $result;
+      }
 
-        //Go and update the associated product
-        $query = "SELECT * FROM Product WHERE Id = $this->prodid";
-        $result = mysqli_query($conn, $query);
-        $resultRow = mysqli_fetch_array($result);
-        $thisProduct = Product::getProductFromDBRow($resultRow);
+      function updateSaleLine($conn){
+        $sqltable = "SaleLine";
+        $query = "UPDATE $sqltable SET ProductId = $this->prodid, Quantity = $this->quantity WHERE Id = $this->id";
 
-        $thisProduct->updateProductData($this->quantity);
-
+        $result = $this->WriteDelDbase($sqltable, $query);
         return $result;
       }
 
       //Delete a SaleLine from the database, and update the associated product's quantity
       function deleteSaleLine($conn){
-        //Get the relevant product
-        $query = "SELECT * FROM Product WHERE Id = $this->prodid";
-        $result = mysqli_query($conn, $query);
-        $resultRow = mysqli_fetch_array($result);
-        $thisProduct = Product::getProductFromDBRow($resultRow);
-
-        //Reduce quantity by the specified amount
-        $productQtyChange = $this->getQuantity() * -1;
-        $thisProduct->updateProductData($productQtyChange);
-
         //Delete the Saleline
         $sqltable = "SaleLine";
         $query = "DELETE FROM $sqltable WHERE Id = $this->id";

--- a/templates/sales.html
+++ b/templates/sales.html
@@ -22,7 +22,7 @@
 			    <select class="form-control" id="product" ng-model="product" ng-options="product.name for product in products"></select>
 			    <label for="qty">Quantity:</label>
 			    <input type="text" class="form-control" id="qty" ng-model="qty" pattern="^[0-9]*$">
-			    <button type="button" class="btn btn-default btn-lg" ng-click="createSaleItem(product, qty)">Add</button>
+			    <button type="button" class="btn btn-default btn-lg" ng-click="createSaleItem(product, qty)">{{addButtonText}}</button>
 			</div>
     	</div>
     	<!-- impliment second set for xs devices -->
@@ -35,8 +35,9 @@
                         <thead>
                             <tr>
                                 <th id="itemName">Name</th>
-                                <th id="itemQty">Quantity</th>
+                                <th id="itemQty">Qty</th>
                                 <th id="itemCost">Cost</th>
+                                <th id="editItem"></th>
                                 <th id="deleteItem"></th>
                             </tr>
                         </thead>
@@ -45,6 +46,7 @@
                                 <td headers="itemName">{{item.name}}</td>
                                 <td headers="itemQty">{{item.qty}}</td>
                                 <td headers="itemCost">{{item.cost | currency:"$"}}</td>
+                                <td headers="editItem"><a class="handbtn" ng-click="editItem(itemArray.indexOf(item))">Edit</a></td>
                                 <td headers="deleteItem" class="btn" ng-click="deleteItem(itemArray.indexOf(item))">X</td>
                             </tr>
                         </tbody>

--- a/tests/DatabaseConstraintTest.php
+++ b/tests/DatabaseConstraintTest.php
@@ -328,7 +328,7 @@ class DatabaseConstraintTest extends DatabaseTestBase
 			'productGroupId' => '1',
 			'name' => 'test',
 			'price' => '1.0',
-			'quantityOnHand' => '0',
+			'quantityOnHand' => '5',
 			'quantitySold' => '0',
 			'quantityToOrder' => '0',
 			'quantityRequested' => '0',


### PR DESCRIPTION
Logic to update product quantities when salelines change has been moved to DB triggers, and there's now an edit button on the Edit Products page, which, when clicked, populates the form like it was when the user was adding the saleline, allowing the user to make changes.
